### PR TITLE
Enabled gdb to always be in mi async mode

### DIFF
--- a/modules/gdb.js
+++ b/modules/gdb.js
@@ -77,6 +77,7 @@ class GDB extends GDBBase {
     trace = doTrace;
     this.allStopMode = allStopMode;
     await this.init();
+    await this.execMI(`-gdb-set mi-async on`);
     if (!allStopMode) await this.enableAsync();
 
     if (stopOnEntry) {


### PR DESCRIPTION
Now we can have gdb be in non-stop or all-stop mode,
even with mi-async being enabled.