### PR TITLE
stack trace building now happens in gdb onStopped,

### DIFF
--- a/modules/executionState.js
+++ b/modules/executionState.js
@@ -2,41 +2,66 @@
  * @typedef {import("./gdb").MidasStackFrame } MidasStackFrame
  * @typedef {import("./gdb").MidasVariable } MidasVariable
  * @typedef {number} VariableReference
+ * @typedef {import("./gdb").GDB } GDB
  */
 
 /// Type that tracks variablesReferences for an execution context (i.e; a thread).
 class ExecutionState {
   threadId;
   /** @type {{ id: VariableReference, shouldManuallyDelete: boolean }[]} - currently managed variable references*/
-  #managedVariableReferences;
+  #managedVariableReferences = [];
   /** @type {MidasStackFrame[]} */
   stack = [];
-
+  #variablesNeedingUpdates = new Map();
+  #stackFrameLevelsToStackFrameIdentifiers = [];
+  #frameVariablesReferences = new Map();
   constructor(threadId) {
     this.threadId = threadId;
-    this.#managedVariableReferences = [];
   }
 
   /**
    * Adds a variable reference that this execution context should track
-   * @param {{id: VariableReference, shouldManuallyDelete: boolean}} `variableReferenceInfo` - the variable reference this execution context
+   * @param {{id: VariableReference, shouldManuallyDelete: boolean}} variableReferenceInfo - the variable reference this execution context
    * should track and if that points to a variable reference which is a child to some other variable reference
    */
-  addTrackedVariableReference({ id, shouldManuallyDelete }) {
+  addTrackedVariableReference({ id, shouldManuallyDelete }, stackFrameIdentifier) {
+    let frameReferences = this.#frameVariablesReferences.get(stackFrameIdentifier) ?? [];
+    frameReferences.push(id);
+    this.#frameVariablesReferences.set(stackFrameIdentifier, frameReferences);
     this.#managedVariableReferences.push({ id, shouldManuallyDelete });
   }
 
   async clear(gdb) {
-    for (const { id, shouldManuallyDelete } of this.#managedVariableReferences) {
-      if (shouldManuallyDelete) {
-        // we only clean up non-children in the backend; gdb MI does the rest for the children
-        let item = gdb.references.get(id);
-        item.cleanUp(gdb);
+    for(let stack of this.stack) {
+      let item = gdb.references.get(stack.id);
+      await item.cleanUp(gdb);
+      let referencedByFrame = this.#frameVariablesReferences.get(stack.id) ?? [];
+      for(const variableReference of referencedByFrame) {
+        gdb.references.delete(variableReference);
       }
-      gdb.references.delete(id);
+
     }
+    this.#frameVariablesReferences.clear();
     this.stack = [];
     this.#managedVariableReferences = [];
+    this.#variablesNeedingUpdates = new Map();
+    this.#stackFrameLevelsToStackFrameIdentifiers = [];
+  }
+  /**
+   *
+   * @param {GDB} gdb
+   * @param {MidasStackFrame[]} selected
+   */
+  async clearSelected(gdb, selected) {
+    for(const stack of selected) {
+      let item = gdb.references.get(stack.id);
+      await item.cleanUp(gdb);
+      let referencedByFrame = this.#frameVariablesReferences.get(stack.id);
+      for(const variableReference of referencedByFrame) {
+        gdb.references.delete(variableReference);
+      }
+      this.#frameVariablesReferences.delete(stack.id);
+    }
   }
 
   updateTopFrame(frame, gdb) {
@@ -49,6 +74,58 @@ class ExecutionState {
       // functions, therefore, this will be caught in stackTraceRequest() in MidasDebugSession
       this.stack[0].line = frame.line;
     }
+  }
+
+  registerVariableObjectChange(variableObjectName, variableObjectValue) {
+    this.#variablesNeedingUpdates.set(variableObjectName, variableObjectValue);
+  }
+
+  getMaybeUpdatedValue(variableObjectName) {
+    return this.#variablesNeedingUpdates.get(variableObjectName);
+  }
+
+  removeUpdatedValue(variableObjectName) {
+    this.#variablesNeedingUpdates.delete(variableObjectName);
+  }
+
+  currentFunction() {
+    return this.stack[0].func;
+  }
+
+  currentStackAddressStart() {
+    return this.stack[0].stackAddressStart;
+  }
+
+  isSameContextAsCurrent(stackStartAddress, functionName) {
+    if(this.stack.length == 0) return false;
+    return this.currentStackAddressStart() == stackStartAddress && this.currentFunction() == functionName;
+  }
+
+  // debug info logging
+  dumpContext() {
+    const logLines = this.stack.map((frame, idx) => `[${idx}] ${frame.name}           - 0x${frame.stackAddressStart.toString(16)}`)
+    console.log(JSON.stringify(logLines, null, 2));
+  }
+
+  pushFrameLevel(stackLevelFrameIdentifier) {
+    this.#stackFrameLevelsToStackFrameIdentifiers.push(stackLevelFrameIdentifier);
+  }
+
+  async setNewContext(stackStartAddress, func, gdb) {
+    let indexOfFrame = this.stack.findIndex(frame => frame.func == func && frame.stackAddressStart == stackStartAddress);
+    if(indexOfFrame != -1) {
+      const levelsToClean = this.stack.splice(0, indexOfFrame);
+      this.#stackFrameLevelsToStackFrameIdentifiers = this.#stackFrameLevelsToStackFrameIdentifiers.slice(indexOfFrame);
+      await this.clearSelected(gdb, levelsToClean);
+      return this.stack.length;
+    } else {
+      await this.clear(gdb);
+      return 0;
+    }
+  }
+
+  getFrameLevel(stackFrameIdentifier) {
+    return this.#stackFrameLevelsToStackFrameIdentifiers.indexOf(stackFrameIdentifier);
   }
 }
 

--- a/modules/variablesrequest/locals.js
+++ b/modules/variablesrequest/locals.js
@@ -8,13 +8,111 @@ const GDB = require("../gdb");
  * @typedef { import("../gdb").MidasVariable } MidasVariable
  */
 
+const isPrimitiveType = (value, childrenCount) => value && (childrenCount == 0);
+const isStructuredOrPointer = (value, childrenCount) => value && (childrenCount > 0);
+const isNotVariable = (value, childrenCount) => !value && (childrenCount == 0);
+
 class LocalsReference extends VariablesReference {
   /** @type {MidasVariable[]}  */
   #variables;
 
+  #initialized = false;
+
   constructor(stackFrameId, threadId, frameLevel) {
     super(stackFrameId, threadId, frameLevel);
     this.#variables = [];
+  }
+
+  async #initRequest(gdb) {
+    let ec = gdb.getExecutionContext(this.threadId);
+    const frameLevel = ec.getFrameLevel(this.variablesReferenceId);
+    this.frameLevel = frameLevel;
+    let result = await gdb.getStackLocals(this.threadId, this.frameLevel);
+    for (const { name, type, value } of result) {
+      if (name == "this") {
+        let nextRef = gdb.generateVariableReference();
+        const voname = `vr_${nextRef}`;
+        // notice the extra * -> we are dereferencing a this pointer
+        const cmd = `-var-create ${voname} * *${name}`;
+        await gdb.execMI(cmd, this.threadId);
+        gdb.references.set(
+          nextRef,
+          new StructsReference(nextRef, this.threadId, this.frameLevel, { variableObjectName: voname, evaluateName: name })
+        );
+        gdb.getExecutionContext(this.threadId).addTrackedVariableReference({ id: nextRef, shouldManuallyDelete: true });
+        let mvar = new GDB.MidasVariable(name, `<${value}> ${type}`, nextRef, voname, value ? false : true, name);
+        this.#variables.push(mvar);
+      } else {
+        let nextRef = gdb.generateVariableReference();
+        let vscodeRef = 0;
+        const voname = `vr_${nextRef}`;
+        let cmd = `-var-create ${voname} * ${name}`;
+        // we have to execute the creation of varObjs first; if we have come across a non-capturing lambda
+        // it will *not* have `value` set, like structured types, but it will also *not* have numchild > 0,
+        // so we must find out this first, to refrain from tracking it
+        const numchild = (await gdb.execMI(cmd, this.threadId)).numchild;
+        if (!value && numchild > 0) {
+          vscodeRef = nextRef;
+          gdb.references.set(
+            nextRef,
+            new StructsReference(nextRef, this.threadId, this.frameLevel, { variableObjectName: voname, evaluateName: name })
+          );
+          gdb.getExecutionContext(this.threadId).addTrackedVariableReference({ id: nextRef, shouldManuallyDelete: true });
+          let mvar = new GDB.MidasVariable(name, value ?? type, vscodeRef, voname, value ? false : true, name);
+          this.#variables.push(mvar);
+        } else if (isNotVariable(value, numchild)) {
+          await gdb.deleteVariableObject(voname);
+          continue;
+        } else if (isStructuredOrPointer(value, numchild)) {
+          // we're *most likely* a pointer to something
+          let nextRef = gdb.generateVariableReference();
+          const deref_voname = `vr_${nextRef}`;
+          // notice the extra * -> we are dereferencing a this pointer
+          const cmd = `-var-create ${deref_voname} * *${name}`;
+          // this is wrapped in a try block because:
+          // below, we try to derefence what we believe to be a pointer, but it doesn't have to be,
+          // it can be an l-value reference or an r-value reference. And they don't have the operator*
+          // so the catch block, is there for these kinds, if they're a reference, they get treated as the code on line 52-59
+          // which does the exact same thing, but for l-values
+          try {
+            let varobj = await gdb.execMI(cmd, this.threadId);
+            // means that the value behind the pointer is a structured type. a pointer, always have 1 numchild
+            // so in order to find out if it's a primitive type, we dereference it and check if there are further children.
+            if (varobj.numchild > 0) {
+              vscodeRef = nextRef;
+              gdb.references.set(
+                nextRef,
+                new StructsReference(nextRef, this.threadId, this.frameLevel, {
+                  variableObjectName: deref_voname,
+                  evaluateName: name,
+                })
+              );
+              gdb.getExecutionContext(this.threadId).addTrackedVariableReference({ id: nextRef, shouldManuallyDelete: true }, this.variablesReferenceId);
+              let mvar = new GDB.MidasVariable(name, `<${value}> ${type}`, nextRef, deref_voname, value ? false : true, name);
+              this.#variables.push(mvar);
+            } else {
+              let mvar = new GDB.MidasVariable(name, value ?? type, vscodeRef, voname, value ? false : true, name);
+              this.#variables.push(mvar);
+            }
+          } catch (isOf_l_or_r_ReferenceTypeError) {
+            vscodeRef = nextRef;
+            gdb.references.set(
+              nextRef,
+              new StructsReference(nextRef, this.threadId, this.frameLevel, { variableObjectName: voname, evaluateName: name }, this.variablesReferenceId)
+            );
+            gdb.getExecutionContext(this.threadId).addTrackedVariableReference({ id: nextRef, shouldManuallyDelete: true }, this.variablesReferenceId);
+            let mvar = new GDB.MidasVariable(name, type, vscodeRef, voname, value ? false : true, name);
+            this.#variables.push(mvar);
+          }
+        } else if(isPrimitiveType(value, numchild)) {
+          gdb.getExecutionContext(this.threadId).addTrackedVariableReference({ id: nextRef, shouldManuallyDelete: true }, this.variablesReferenceId);
+          const doesNotReferenceOtherVariables = 0;
+          let mvar = new GDB.MidasVariable(name, value, doesNotReferenceOtherVariables, voname, value ? false : true, name);
+          this.#variables.push(mvar);
+        }
+      }
+    }
+    this.#initialized = true;
   }
 
   /**
@@ -23,106 +121,41 @@ class LocalsReference extends VariablesReference {
    * @returns { Promise<VariablesResponse> }
    */
   async handleRequest(response, gdb) {
-    if (this.#variables.length == 0) {
-      let result = await gdb.getStackLocals(this.threadId, this.frameLevel);
-      for (const { name, type, value } of result) {
-        if (name == "this") {
-          let nextRef = gdb.generateVariableReference();
-          const voname = `vr_${nextRef}`;
-          // notice the extra * -> we are dereferencing a this pointer
-          const cmd = `-var-create ${voname} * *${name}`;
-          await gdb.execMI(cmd, this.threadId).then((res) => res.numchild);
-          gdb.references.set(
-            nextRef,
-            new StructsReference(nextRef, this.threadId, this.frameLevel, { variableObjectName: voname, evaluateName: name })
-          );
-          gdb.getExecutionContext(this.threadId).addTrackedVariableReference({ id: nextRef, shouldManuallyDelete: true });
-          let mvar = new GDB.MidasVariable(name, `<${value}> ${type}`, nextRef, voname, value ? false : true, name);
-          this.#variables.push(mvar);
-        } else {
-          let nextRef = gdb.generateVariableReference();
-          let vscodeRef = 0;
-          const voname = `vr_${nextRef}`;
-          let cmd = `-var-create ${voname} * ${name}`;
-          // we have to execute the creation of varObjs first; if we have come across a non-capturing lambda
-          // it will *not* have `value` set, like structured types, but it will also *not* have numchild > 0,
-          // so we must find out this first, to refrain from tracking it
-          let numchild = await gdb.execMI(cmd, this.threadId).then((res) => res.numchild);
-          if (!value && numchild > 0) {
-            vscodeRef = nextRef;
-            gdb.references.set(
-              nextRef,
-              new StructsReference(nextRef, this.threadId, this.frameLevel, { variableObjectName: voname, evaluateName: name })
-            );
-            gdb.getExecutionContext(this.threadId).addTrackedVariableReference({ id: nextRef, shouldManuallyDelete: true });
-            let mvar = new GDB.MidasVariable(name, value ?? type, vscodeRef, voname, value ? false : true, name);
-            this.#variables.push(mvar);
-          } else if (!value && numchild == 0) {
-            await gdb.deleteVariableObject(voname);
-            continue;
-          } else if (value && numchild > 0) {
-            // we're *most likely* a pointer to something
-            let nextRef = gdb.generateVariableReference();
-            const deref_voname = `vr_${nextRef}`;
-            // notice the extra * -> we are dereferencing a this pointer
-            const cmd = `-var-create ${deref_voname} * *${name}`;
-            // this is wrapped in a try block because:
-            // below, we try to derefence what we believe to be a pointer, but it doesn't have to be,
-            // it can be an l-value reference or an r-value reference. And they don't have the operator*
-            // so the catch block, is there for these kinds, if they're a reference, they get treated as the code on line 52-59
-            // which does the exact same thing, but for l-values
-            try {
-              let varobj = await gdb.execMI(cmd, this.threadId);
-              // means that the value behind the pointer is a structured type. a pointer, always have 1 numchild
-              // so in order to find out if it's a primitive type, we dereference it and check if there are further children.
-              if (varobj.numchild > 0) {
-                vscodeRef = nextRef;
-                gdb.references.set(
-                  nextRef,
-                  new StructsReference(nextRef, this.threadId, this.frameLevel, {
-                    variableObjectName: deref_voname,
-                    evaluateName: name,
-                  })
-                );
-                gdb.getExecutionContext(this.threadId).addTrackedVariableReference({ id: nextRef, shouldManuallyDelete: true });
-                let mvar = new GDB.MidasVariable(name, `<${value}> ${type}`, nextRef, deref_voname, value ? false : true, name);
-                this.#variables.push(mvar);
-              } else {
-                let mvar = new GDB.MidasVariable(name, value ?? type, vscodeRef, voname, value ? false : true, name);
-                this.#variables.push(mvar);
-              }
-            } catch (isOf_l_or_r_ReferenceTypeError) {
-              vscodeRef = nextRef;
-              gdb.references.set(
-                nextRef,
-                new StructsReference(nextRef, this.threadId, this.frameLevel, { variableObjectName: voname, evaluateName: name })
-              );
-              gdb.getExecutionContext(this.threadId).addTrackedVariableReference({ id: nextRef, shouldManuallyDelete: true });
-              let mvar = new GDB.MidasVariable(name, type, vscodeRef, voname, value ? false : true, name);
-              this.#variables.push(mvar);
-            }
-          }
-        }
-      }
+    if(!this.#initialized) {
+      await this.#initRequest(gdb);
       response.body = {
         variables: this.#variables,
       };
     } else {
       // we need to update the stack frame
-      await gdb.updateMidasVariables(this.threadId, this.#variables);
+      let ec = gdb.executionContexts.get(this.threadId);
+      for(let v of this.#variables) {
+        const changeList = await gdb.execMI(`-var-update --all-values ${v.variableObjectName}`);
+        for(const change of changeList.changelist) {
+          ec.registerVariableObjectChange(change.name, change.value);
+        }
+        let changeValue = ec.getMaybeUpdatedValue(v.variableObjectName);
+        if(changeValue) {
+          v.value = changeValue;
+          ec.removeUpdatedValue(v.variableObjectName);
+        }
+      }
+
       response.body = {
         variables: this.#variables,
       };
     }
     return response;
   }
+
   /**
    * @param { GDB } gdb - reference to the GDB backend
    */
   async cleanUp(gdb) {
     for (const v of this.#variables) {
-      await gdb.deleteVariableObject(v.voName);
+      await gdb.deleteVariableObject(v.variableObjectName);
     }
+    gdb.references.delete(this.variablesReferenceId);
   }
   /**
    * Sets a new value of a named object (variable object) that this reference tracks or manages.
@@ -135,7 +168,7 @@ class LocalsReference extends VariablesReference {
   async update(response, gdb, namedObject, value) {
     for (const v of this.#variables) {
       if (v.name == namedObject) {
-        let res = await gdb.execMI(`-var-assign ${v.voName} "${value}"`, this.threadId);
+        let res = await gdb.execMI(`-var-assign ${v.variableObjectName} "${value}"`, this.threadId);
         if (res.value) {
           v.value = res.value;
           response.body = {

--- a/modules/variablesrequest/registers.js
+++ b/modules/variablesrequest/registers.js
@@ -36,7 +36,7 @@ class RegistersReference extends VariablesReference {
    */
   async cleanUp(gdb) {
     for (const v of this.#registerVariables) {
-      await gdb.deleteVariableObject(v.voName);
+      await gdb.deleteVariableObject(v.variableObjectName);
     }
   }
 }

--- a/test/cppworkspace/test/src/main.cpp
+++ b/test/cppworkspace/test/src/main.cpp
@@ -246,7 +246,52 @@ void two_impls() {
   take_interface(bb);
 }
 
+struct Struct {
+  int i;
+  float f;
+  const char* name; 
+};
 
+struct Bar {
+  int j = 0;
+  Struct* s;
+};
+
+
+
+Struct variablesRequestTest(Struct s) {
+  // set first breakpoint here
+  const auto new_i = s.i + 10;
+  const auto new_f = s.f + 10.0f;
+  s.i = new_i;
+  s.f = new_f;
+  return s;
+}
+
+void variablesRequestTestReference(Struct& s) {
+  const auto i = s.i + 10;
+  const auto f = s.f + 10.0f;
+  s.i = i;
+  s.f = f;  
+}
+
+int testSubChildUpdate(Bar* b) {
+    b->j++;
+    variablesRequestTestReference(*b->s);
+    auto res = b->s->f;
+    return res;
+}
+
+void variablesRequestTestPointer(Struct* s) {
+  auto local_ptr = s;
+  const auto i = local_ptr->i + 10;
+  const auto f = local_ptr->f + 10.0f;
+  variablesRequestTestReference(*s);
+  local_ptr->i += i;
+  local_ptr->f += f;
+  variablesRequestTestReference(*s);
+  local_ptr = nullptr;
+}
 
 int main(int argc, const char **argv) {
   const auto somelocal = 42;
@@ -295,4 +340,11 @@ int main(int argc, const char **argv) {
   auto a = move_todo(std::move(tmp));
   std::cout << a.title() << std::endl;
   two_impls();
+
+  auto somestruct = new Struct { .i = 10, .f = 10.0f, .name = "somestruct" };
+  auto copied_somestruct = variablesRequestTest(*somestruct);
+  variablesRequestTestPointer(&copied_somestruct);
+
+  auto barptr = new Bar{.j = 100, .s = new Struct { .i = 10, .f = 10.0f, .name = "somestruct_refByBar" }};
+  testSubChildUpdate(barptr);
 }


### PR DESCRIPTION
instead in the twice-called stackTraceRequest.

when updating variables, instead of reading each individually
we now retrieve the changeList and only read the updated values
from that, reducing the calls to execMI

added additional "scenarios" to cpp file to test functionality

cleanup

removed unconditional debug logging