### PR TITLE
Symbol lookup optimized & hot reloading of scripts

### DIFF
--- a/modules/commandsRegistry.js
+++ b/modules/commandsRegistry.js
@@ -61,7 +61,11 @@ function getVSCodeCommands() {
     vscode.debug.activeDebugSession.customRequest("set-watchpoint", { location: `${container.evaluateName}.${variable.name}` });
   });
 
-  return [rrRecord, continueAll, pauseAll, reverseFinish, watch];
+  let hotReloadScripts = registerCommand("midas.hot-reload-scripts", () => {
+    vscode.debug.activeDebugSession.customRequest("hot-reload-scripts");
+  });
+
+  return [rrRecord, continueAll, pauseAll, reverseFinish, watch, hotReloadScripts];
 }
 
 module.exports = {

--- a/modules/debugSession.js
+++ b/modules/debugSession.js
@@ -596,6 +596,13 @@ class MidasDebugSession extends DebugAdapter.DebugSession {
       case "set-watchpoint":
         await this.gdb.setReadWatchPoint(args.location);
         break;
+      case "hot-reload-scripts":
+        try {
+          await this.gdb.setup();
+          console.log(`Successfully hot reloaded scripts`);
+        } catch(err) {
+          console.log(`failed to reload scripts ${err}`);
+        }
       default:
         vscode.window.showInformationMessage(`Unknown request: ${command}`);
     }
@@ -656,6 +663,10 @@ class MidasDebugSession extends DebugAdapter.DebugSession {
   // terminal where rr has been started in
   registerTerminal(terminal) {
     this.#terminal = terminal;
+  }
+
+  reloadScripts() {
+    this.gdb.setup();
   }
 }
 

--- a/modules/gdb.js
+++ b/modules/gdb.js
@@ -527,15 +527,14 @@ class GDB extends GDBMixin(GDBBase) {
     } else {
       const start = await ec.setNewContext(stackStartAddress, frame.func, this);
       let frames = await this.getStack(start, 20 - start, threadId);
-      let newFrames = frames.length;
       for (let frame of frames) {
         const argsVarRef = this.nextVarRef;
         const frameIdVarRef = this.nextVarRef;
         const registerVarRef = this.nextVarRef;
-        let state = new StackFrameState(frameIdVarRef, argsVarRef, threadId, +frame.level);
-        this.references.set(registerVarRef, new RegistersReference(frameIdVarRef, threadId, +frame.level));
-        this.references.set(frameIdVarRef, new LocalsReference(frameIdVarRef, threadId, +frame.level, argsVarRef, registerVarRef, state));
-        this.references.set(argsVarRef, new ArgsReference(argsVarRef, threadId, +frame.level, state));
+        let state = new StackFrameState(frameIdVarRef, argsVarRef, threadId);
+        this.references.set(registerVarRef, new RegistersReference(frameIdVarRef, threadId));
+        this.references.set(frameIdVarRef, new LocalsReference(frameIdVarRef, threadId, argsVarRef, registerVarRef, state));
+        this.references.set(argsVarRef, new ArgsReference(argsVarRef, threadId, state));
         ec.addTrackedVariableReference(registerVarRef, frameIdVarRef);
         ec.addTrackedVariableReference(argsVarRef, frameIdVarRef);
 
@@ -1050,10 +1049,10 @@ class GDB extends GDBMixin(GDBBase) {
         const stackFrameArgsIdentifier = this.nextVarRef;
         const stackFrameIdentifier = this.nextVarRef;
         const registerScopeVariablesReference = this.nextVarRef;
-        this.references.set(registerScopeVariablesReference, new RegistersReference(stackFrameIdentifier, threadId, +frame.level));
-        let state = new StackFrameState(stackFrameIdentifier, stackFrameArgsIdentifier, threadId, +frame.level);
-        this.references.set(stackFrameIdentifier, new LocalsReference(stackFrameIdentifier, threadId, +frame.level, stackFrameArgsIdentifier, registerScopeVariablesReference, state));
-        this.references.set(stackFrameArgsIdentifier, new ArgsReference(stackFrameArgsIdentifier, threadId, +frame.level, state));
+        this.references.set(registerScopeVariablesReference, new RegistersReference(stackFrameIdentifier, threadId));
+        let state = new StackFrameState(stackFrameIdentifier, stackFrameArgsIdentifier, threadId);
+        this.references.set(stackFrameIdentifier, new LocalsReference(stackFrameIdentifier, threadId, stackFrameArgsIdentifier, registerScopeVariablesReference, state));
+        this.references.set(stackFrameArgsIdentifier, new ArgsReference(stackFrameArgsIdentifier, threadId, state));
 
         ec.addTrackedVariableReference(registerScopeVariablesReference, stackFrameArgsIdentifier);
         ec.addTrackedVariableReference(stackFrameArgsIdentifier, stackFrameArgsIdentifier);

--- a/modules/variablesrequest/args.js
+++ b/modules/variablesrequest/args.js
@@ -10,8 +10,8 @@ class ArgsReference extends VariablesReference {
   /** @type {import("./stackFramestate").StackFrameState}*/
   #stackFrameState;
 
-  constructor(argScopeVariableReference, threadId, frameLevel, stackFrameState) {
-    super(argScopeVariableReference, threadId, frameLevel);
+  constructor(argScopeVariableReference, threadId, stackFrameState) {
+    super(argScopeVariableReference, threadId);
     this.#stackFrameState = stackFrameState;
   }
 

--- a/modules/variablesrequest/locals.js
+++ b/modules/variablesrequest/locals.js
@@ -12,8 +12,8 @@ class LocalsReference extends VariablesReference {
   /** @type {import("./stackFramestate").StackFrameState }*/
   state;
 
-  constructor(stackFrameId, threadId, frameLevel, argScopeIdentifer, registerScopeIdentifier, state) {
-    super(stackFrameId, threadId, frameLevel);
+  constructor(stackFrameId, threadId, argScopeIdentifer, registerScopeIdentifier, state) {
+    super(stackFrameId, threadId);
     if(!state) debugger;
     this.argScopeIdentifier = argScopeIdentifer;
     this.registerScopeIdentifier = registerScopeIdentifier;

--- a/modules/variablesrequest/registers.js
+++ b/modules/variablesrequest/registers.js
@@ -11,8 +11,8 @@ class RegistersReference extends VariablesReference {
   /** @type {VSCodeVariable[]}  */
   #registerVariables;
 
-  constructor(stackFrameId, threadId, frameLevel) {
-    super(stackFrameId, threadId, frameLevel);
+  constructor(stackFrameId, threadId) {
+    super(stackFrameId, threadId);
     this.#registerVariables = [];
   }
 
@@ -23,7 +23,8 @@ class RegistersReference extends VariablesReference {
    */
   async handleRequest(response, gdb) {
     // todo(simon): this is logic that DebugSession should not handle. Partially, this stuff gdb.js should be responsible for
-    await gdb.selectStackFrame(this.frameLevel, this.threadId);
+    const frameLevel = super.getFrameLevel(gdb);
+    await gdb.selectStackFrame(frameLevel, this.threadId);
     let miResult = await gdb.execMI(`-data-list-register-values N ${gdb.generalPurposeRegCommandString}`);
     response.body = {
       variables: miResult["register-values"].map((res, index) => new DebugAdapter.Variable(gdb.registerFile[index], res.value)),

--- a/modules/variablesrequest/statics.js
+++ b/modules/variablesrequest/statics.js
@@ -45,7 +45,7 @@ class StaticsReference extends VariablesReference {
    * @returns { Promise<VariablesResponse> }
    */
   async handleRequest(response, gdb) {
-    const frameLevel = super.getFrameLevel(gdb);
+    const frameLevel = gdb.getExecutionContext(this.threadId).getFrameLevel(this.stackFrameIdentifier);
     let result = []
     let children = await gdb.getContentsOfStatic(this.threadId, frameLevel, this.evaluateName);
     for(const child of children) {

--- a/modules/variablesrequest/statics.js
+++ b/modules/variablesrequest/statics.js
@@ -30,12 +30,11 @@ class StaticsReference extends VariablesReference {
    * 
    * @param { number } variablesReference 
    * @param { number } threadId 
-   * @param { number } frameLevel 
    * @param { string } evaluateName
    * @param { number } stackFrameIdentifier 
    */
-  constructor(variablesReference, threadId, frameLevel, evaluateName, stackFrameIdentifier) {
-    super(variablesReference, threadId, frameLevel);
+  constructor(variablesReference, threadId, evaluateName, stackFrameIdentifier) {
+    super(variablesReference, threadId);
     this.stackFrameIdentifier = stackFrameIdentifier;
     this.evaluateName = evaluateName;
   }
@@ -46,8 +45,9 @@ class StaticsReference extends VariablesReference {
    * @returns { Promise<VariablesResponse> }
    */
   async handleRequest(response, gdb) {
+    const frameLevel = super.getFrameLevel(gdb);
     let result = []
-    let children = await gdb.getContentsOfStatic(this.threadId, this.frameLevel, this.evaluateName);
+    let children = await gdb.getContentsOfStatic(this.threadId, frameLevel, this.evaluateName);
     for(const child of children) {
       const path = `${this.evaluateName}.${child.name}`;
       if(child.isPrimitive) {
@@ -57,7 +57,7 @@ class StaticsReference extends VariablesReference {
         let nextRef = this.namesRegistered.get(child.name);
         if(!nextRef) {
           nextRef = gdb.generateVariableReference();
-          let subStructHandler = new StructsReference(nextRef, this.threadId, this.frameLevel, path, this.stackFrameIdentifier);
+          let subStructHandler = new StructsReference(nextRef, this.threadId, path, this.stackFrameIdentifier);
           gdb.references.set(
             nextRef,
             subStructHandler

--- a/modules/variablesrequest/structs.js
+++ b/modules/variablesrequest/structs.js
@@ -44,7 +44,7 @@ class StructsReference extends VariablesReference {
    * @returns { Promise<VariablesResponse> }
    */
   async handleRequest(response, gdb) {
-    const frameLevel = super.getFrameLevel(gdb);
+    const frameLevel = gdb.getExecutionContext(this.threadId).getFrameLevel(this.stackFrameIdentifier);
     let cmd_result = await gdb.getContentsOf(this.threadId, frameLevel, this.evaluateName);
     if(cmd_result) {
       response.body = {
@@ -183,6 +183,10 @@ class StructsReference extends VariablesReference {
       await gdb.execMI(`-var-delete ${vo_name}`);
       return err_response(response, `${namedObject} is not editable`);
     }
+  }
+
+  getFrameLevel(gdb) {
+    return gdb.getExecutionContext(this.threadId).getFrameLevel(this.stackFrameIdentifier);
   }
 }
 

--- a/modules/variablesrequest/variablesReference.js
+++ b/modules/variablesrequest/variablesReference.js
@@ -35,12 +35,10 @@ class VariablesReference {
   /**
    * @param {number} variablesReference - can be a stackFrameId or an id for a variable
    * @param {number} threadId - the thread which this variable or stackframe exists in
-   * @param {number} frameLevel - the (current) frame level this variable or stack frame lives on
    */
-  constructor(variablesReference, threadId, frameLevel) {
+  constructor(variablesReference, threadId) {
     this.variablesReferenceId = variablesReference;
     this.threadId = threadId;
-    this.frameLevel = frameLevel;
   }
 
   /**
@@ -52,6 +50,9 @@ class VariablesReference {
     throw new Error("Base class VariablesReference should not be instantiated. Merely for documentation purposes.");
   }
 
+  getFrameLevel(gdb) {
+    return gdb.getExecutionContext(this.threadId).getFrameLevel(this.variablesReferenceId);
+  }
   /**
    * This "virtual" function must uphold this contract:
    * Clean up any data in the backend, that it promises to manage. How or where, is not important, as long as this

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
         "title": "Set read-access watchpoint",
         "shortTitle": "Watch variable",
         "icon": "$(eye-watch)"
+      },
+      {
+        "command": "midas.hot-reload-scripts",
+        "title": "Re-initializes Midas",
+        "shortTitle": "Re-initialize"
       }
     ],
     "menus": {

--- a/test/cppworkspace/test/src/testcase_namespaces/baseclasses.cpp
+++ b/test/cppworkspace/test/src/testcase_namespaces/baseclasses.cpp
@@ -3,11 +3,11 @@ namespace baseclasses
 {
     void main() {
         Bar* a = new Bar{10};
-        Bar* b = new Bar{20};
-        Bar c{10};
+        Bar* someLongBar = new Bar{20};
+        Bar cSomeLongBarValue{10};
         Bar d{20};
         Zoo z{10};
-        Zoo* x = new Zoo{10};
+        Zoo* someLongerZooName = new Zoo{10};
         Zoo* y = new Zoo{20};
         Tricky t{1337};
         Tricky* tp = new Tricky{42};


### PR DESCRIPTION
## Symbol lookup
Symbol lookup time has been cut in half for average use cases, tested against both the user test applications in cppworkspace, but performed even better when testing against Firefox & rr.

Some form of heuristic needs to be introduced here though, because in some cases it was almost 3 times as slow, and I have not been able to identify why that is the case.

## Reloading of scripts
Added command for reloading scripts to ease the development process by a large margin. As far as I know, there should be some way to indicate that an extension is in "development mode", so that this could be automatically removed from production / release mode. I don't know how to do that right now though, so this will be added to issues.