### PR TITLE
fixing conflict hell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ test/cppworkspace/thread/build
 .vscode/settings.json
 
 update.log
-foo.py
+time.log
+debug.log
+performance_time.log

--- a/modules/buildMode.js
+++ b/modules/buildMode.js
@@ -1,7 +1,7 @@
 const vscode = require("vscode");
 
 /**
- * Run-mode settings of Midas. Basically equivalent to "build mode" for compiled languages.
+ * Run-mode settings of Midas. Loads scripts and holds trace of GDB events and debug logging.
  */
 class MidasRunMode {
   #contents = [];
@@ -58,6 +58,14 @@ class MidasRunMode {
       if(this.#trace || this.#debug) console.log(`Intializing contents of file ${file}`);
       await gdb.execPy(contents);
     }
+  }
+
+  get trace() {
+    return this.#trace;
+  }
+
+  get debug() {
+    return this.#debug;
   }
 }
 

--- a/modules/debugSession.js
+++ b/modules/debugSession.js
@@ -144,11 +144,11 @@ class MidasDebugSession extends DebugAdapter.DebugSession {
       this.gdb = new GDB(this, args);
       this.gdb.withRR = true;
       this.gdb.setupEventHandlers(args.stopOnEntry);
-      await this.gdb.startWithRR(args.program, args.stopOnEntry, args.trace);
+      await this.gdb.startWithRR(args.program, args.stopOnEntry);
     } else if (args.type == "midas") {
       this.gdb = new GDB(this, args);
       this.gdb.setupEventHandlers(args.stopOnEntry);
-      await this.gdb.start(args.program, args.stopOnEntry, !args.noDebug, args.trace, args.allStopMode ?? false);
+      await this.gdb.start(args.program, args.stopOnEntry, args.allStopMode ?? false);
     }
   }
 

--- a/modules/gdb.js
+++ b/modules/gdb.js
@@ -25,7 +25,7 @@ const { RegistersReference } = require("./variablesrequest/registers");
 const {StackFrameState} = require("./variablesrequest/stackFramestate");
 const {ArgsReference} = require("./variablesrequest/args");
 const { MidasDebugSession } = require("./debugSession");
-let trace = true;
+let trace = false;
 let LOG_ID = 0;
 function log(location, payload) {
   if (!trace) {
@@ -204,9 +204,9 @@ class GDB extends GDBMixin(GDBBase) {
     await runModeSettings.initializeLoadedScripts(this);
   }
 
-  async startWithRR(program, stopOnEntry, doTrace) {
+  async startWithRR(program, stopOnEntry) {
     this.#program = path.basename(program);
-    trace = doTrace;
+    trace = this.#target.buildSettings.trace;
     await this.init();
     // await this.attachOnFork();
     this.registerAsAllStopMode();
@@ -223,9 +223,9 @@ class GDB extends GDBMixin(GDBBase) {
     this.#target.sendEvent(new StoppedEvent("entry", 1));
   }
 
-  async start(program, stopOnEntry, debug, doTrace, allStopMode) {
+  async start(program, stopOnEntry, allStopMode) {
     this.#program = path.basename(program);
-    trace = doTrace;
+    trace = this.#target.buildSettings.trace;
     this.allStopMode = allStopMode;
     await this.init();
     await this.setup();
@@ -310,9 +310,7 @@ class GDB extends GDBMixin(GDBBase) {
         await this.continueAll();
       }
     } else {
-      // todo(simon): this needs a custom implementation, like in the above if branch
-      //  especially when it comes to rr integration
-      await this.reverseProceed(threadId);
+      await this.execCLI("reverse-continue");
     }
   }
 

--- a/modules/python/utils.py
+++ b/modules/python/utils.py
@@ -9,20 +9,22 @@ import functools
 import time
 
 if isDevelopmentBuild:
-    time_handler = logging.handlers.WatchedFileHandler("time.log", mode="w")
+    time_handler = logging.handlers.WatchedFileHandler(
+        "performance_time.log", mode="w")
     formatter = logging.Formatter(logging.BASIC_FORMAT)
     time_handler.setFormatter(formatter)
     time_logger = logging.getLogger("time-logger")
     time_logger.setLevel(logging.DEBUG)
     time_logger.addHandler(time_handler)
 
-misc_handler = logging.handlers.WatchedFileHandler("update.log", mode="w")
+misc_handler = logging.handlers.WatchedFileHandler("debug.log", mode="w")
 misc_formatter = logging.Formatter(logging.BASIC_FORMAT)
 misc_handler.setFormatter(misc_formatter)
 
 misc_logger = logging.getLogger("update-logger")
 misc_logger.setLevel(logging.DEBUG)
 misc_logger.addHandler(misc_handler)
+
 
 def getFunctionBlock(frame) -> gdb.Block:
     block = frame.block()
@@ -32,25 +34,31 @@ def getFunctionBlock(frame) -> gdb.Block:
         return None
     return block
 
+
 def logExceptionBacktrace(errmsg, exception):
-        misc_logger.error("{} Exception info: {}".format(errmsg, exception))
-        misc_logger.error(traceback.format_exc())
+    misc_logger.error("{} Exception info: {}".format(errmsg, exception))
+    misc_logger.error(traceback.format_exc())
+
 
 def selectThreadAndFrame(threadId, frameLevel):
     gdb.execute("thread {}".format(threadId))
     gdb.execute("frame {}".format(frameLevel))
 
+
 def parseStringArgs(arg):
     return gdb.string_to_argv(arg)
 
+
 def prepareOutput(cmdName, contents):
     return '<gdbjs:cmd:{0} {1} {0}:cmd:gdbjs>'.format(cmdName, contents)
+
 
 def output(name, result):
     res = json.dumps(result, ensure_ascii=False)
     msg = prepareOutput(name, res)
     sys.stdout.write(msg)
     sys.stdout.flush()
+
 
 def typeIsPrimitive(valueType):
     try:
@@ -62,22 +70,27 @@ def typeIsPrimitive(valueType):
     except TypeError:
         return True
 
+
 def memberIsReference(type):
     code = type.code
     return code == gdb.TYPE_CODE_PTR or code == gdb.TYPE_CODE_REF or code == gdb.TYPE_CODE_RVALUE_REF
 
+
 def getMembersRecursively(field, memberList, statics):
     if field.bitsize > 0:
-        misc_logger.info("field {} is possibly a bitfield of size {}".format(field.name, field.bitsize))
+        misc_logger.info("field {} is possibly a bitfield of size {}".format(
+            field.name, field.bitsize))
     if hasattr(field, 'bitpos'):
         if field.is_base_class:
             for f in field.type.fields():
-                getMembersRecursively(f, memberList=memberList, statics=statics)
+                getMembersRecursively(
+                    f, memberList=memberList, statics=statics)
         else:
             if field.name is not None and not field.name.startswith("_vptr"):
                 memberList.append(field.name)
     else:
         statics.append(field.name)
+
 
 def getMembers(field, memberList, statics, baseclasses):
     if hasattr(field, 'bitpos') and field.name is not None and not field.name.startswith("_vptr") and not field.is_base_class:
@@ -87,46 +100,35 @@ def getMembers(field, memberList, statics, baseclasses):
     elif not hasattr(field, "bitpos"):
         statics.append(field.name)
 
-def getValue(value):
-    print("Trying to get value of {0}".format(value))
-    if memberIsReference(value.type):
-        try:
-            v = value.referenced_value()
-            return v
-        except gdb.MemoryError:
-            return value
-    else:
-        return value
 
-def getElement(key, map):
-    try:
-        r = map[key]
-        return r
-    except KeyError:
-        return None
+def variable_display(name, display, isPrimitive, static, synthetic):
+    return {"name": name, "display": display, "isPrimitive": isPrimitive, "static": static, "synthetic": synthetic}
 
-def display(name, value, isPrimitive):
+
+def display(name, value, isPrimitive, synthetic=False):
     if value.is_optimized_out:
         # we set all optimized values to primitives, because we don't want a scope for them in VSCode
-        return { "name": name, "display": "<optimized out>", "isPrimitive": True, "static": False }
+        return variable_display(name=name, display="<optimized out>", isPrimitive=True, static=False, synthetic=True)
     try:
         if value.type.code == gdb.TYPE_CODE_PTR:
             if isPrimitive:
-                return { "name": name, "display": "<{}> {}".format(value.dereference().address, value), "isPrimitive": isPrimitive, "static": False }
+                return variable_display(name=name, display="<{}> {}".format(value.dereference().address, value), isPrimitive=isPrimitive, static=False, synthetic=synthetic)
             else:
-                return { "name": name, "display": "<{}> {}".format(value.dereference().address, value.type), "isPrimitive": isPrimitive, "static": False }
+                return variable_display(name=name, display="<{}> {}".format(value.dereference().address, value.type), isPrimitive=isPrimitive, static=False, synthetic=synthetic)
         else:
             if isPrimitive:
-                return { "name": name, "display": "{}".format(value), "isPrimitive": isPrimitive, "static": False }
+                return variable_display(name=name, display="{}".format(value), isPrimitive=isPrimitive, static=False, synthetic=synthetic)
             else:
-                return { "name": name, "display": "{}".format(value.type), "isPrimitive": isPrimitive, "static": False }
+                return variable_display(name=name, display="{}".format(value.type), isPrimitive=isPrimitive, static=False, synthetic=synthetic)
     except:
-        return { "name": name, "display": "<invalid address> {}".format(value.type), "isPrimitive": isPrimitive, "static": False }
+        return variable_display(name=name, display="<invalid address> {}".format(value.type), isPrimitive=isPrimitive, static=False, synthetic=True)
+
 
 def base_class_display(name, type):
-    return { "name": name, "display": "{} (base)".format(type) }
+    return {"name": name, "display": "{} (base)".format(type)}
+
 
 def static_display(name, type):
     isPrimitive = True if type.tag is None else False
     typeName = type.tag if type.tag is not None else type
-    return { "name": name, "display": "static {}".format(typeName), "isPrimitive": isPrimitive, "static": True }
+    return {"name": name, "display": "static {}".format(typeName), "isPrimitive": isPrimitive, "static": True, "synthetic": False}

--- a/modules/variablesrequest/structs.js
+++ b/modules/variablesrequest/structs.js
@@ -169,8 +169,8 @@ class StructsReference extends VariablesReference {
    */
   async update(response, gdb, namedObject, value) {
     const vo_name = `ASSIGN_TEMPORARY_${this.evaluateName}_${namedObject}`;
-    let res = await gdb.execMI(`-var-create ${vo_name} * ${this.evaluateName}.${namedObject}`);
     try {
+      let res = await gdb.execMI(`-var-create ${vo_name} * ${this.evaluateName}.${namedObject}`);
       res = await gdb.execMI(`-var-assign ${vo_name} "${value}"`, this.threadId);
       await gdb.execMI(`-var-delete ${vo_name}`);
       if (res.value) {
@@ -180,7 +180,9 @@ class StructsReference extends VariablesReference {
         return response;
       }
     } catch(err) {
-      await gdb.execMI(`-var-delete ${vo_name}`);
+      try {
+        await gdb.execMI(`-var-delete ${vo_name}`);
+      } catch(e) {}
       return err_response(response, `${namedObject} is not editable`);
     }
   }

--- a/package.json
+++ b/package.json
@@ -118,9 +118,16 @@
                 "default": true
               },
               "trace": {
-                "type": "boolean",
-                "description": "Turns logging on or off",
-                "default": false
+                "type": ["string"],
+                "description": "Debug trace logging",
+                "enum": ["Off", "GDB Events", "Python logs", "Full"],
+                "default": "Off",
+                "enumDescriptions": [
+                  "Turn all logging off",
+                  "Turn trace logging of GDB events on",
+                  "Turn debug logging of from Python on",
+                  "Turn on additional debug logging to time.log and update.log, made by Python scripts"
+                ]
               },
               "args": {
                 "type": "string[]",
@@ -180,8 +187,8 @@
             "name": "Debug binary",
             "program": "${workspaceFolder}/${2:binary}",
             "stopOnEntry": true,
-            "trace": false,
-            "allStopMode": false,
+            "trace": "Off",
+            "allStopMode": true,
             "cwd": "${workspaceFolder}",
             "mode": "gdb"
           },
@@ -191,7 +198,7 @@
             "name": "Launch replay session",
             "program": "${workspaceFolder}/${2:binary}",
             "stopOnEntry": true,
-            "trace": false,
+            "trace": "Off",
             "cwd": "${workspaceFolder}",
             "mode": "rr",
             "serverAddress": "localhost:50505",
@@ -212,8 +219,8 @@
               "program": "^\"\\${workspaceFolder}/path/binary\"",
               "cwd": "^\"\\${workspaceFolder}\"",
               "stopOnEntry": true,
-              "trace": false,
-              "allStopMode": false,
+              "trace": "Off",
+              "allStopMode": true,
               "mode": "gdb"
             }
           },
@@ -227,7 +234,7 @@
               "name": "${1:Launch Debug}",
               "cwd": "^\"\\${workspaceFolder}\"",
               "stopOnEntry": true,
-              "trace": false,
+              "trace": "Off",
               "debuggerPath": "gdb",
               "mode": "rr",
               "serverAddress": "localhost:50505",

--- a/test/cppworkspace/thread/src/main.cpp
+++ b/test/cppworkspace/thread/src/main.cpp
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <iomanip>
 #include <cstdlib>
+#include <tuple>
 
 std::mutex g_stdio_mutex;
 struct Foo {
@@ -146,8 +147,15 @@ auto test_evaluate_variables_when_passing_through_scopes() {
   std::cout << w << ", " << h << std::endl;
 }
 
+void tuple_tuples() {
+  std::tuple<int, std::tuple<int, int, std::string>, std::string> hmm{1, {2,3, "inner"}, "outer"};
+  std::cout << "tuples are... meh" << std::endl;
+}
+
 int main(int argc, const char **argv) {
+  std::string hw = "Hello World";
   vecOfString();
+  tuple_tuples();
   auto w = 200;
   auto h = 200;
   test_evaluate_variables_when_passing_through_scopes();


### PR DESCRIPTION
Added rudimentary logging facilities, these should be better defined though.

Pretty printing facilities is now used; for types that have difficult layouts, pretty printing should be the go-to, and it's up to the user to make sure their types have pretty printers defined for them. the std library has pretty printers defined in GDB, so this _shouldn't_ be a problem. For instance; std::tuple will, without a pretty printer basically just show garbage due to the fact that it's member names are all named the same and thus can't be resolved, without a pretty printer.