### PR TITLE
external console disposal functionality fully working

### DIFF
--- a/modules/gdb.js
+++ b/modules/gdb.js
@@ -196,7 +196,7 @@ class GDB extends GDBMixin(GDBBase) {
     // const { getVar, midasPy } = require("./scripts");
     await this.setup();
     if(this.config.externalConsole) {
-      this.#target.addTerminalExitHandler(() => {
+      this.#target.registerTerminal(this.#target.terminal, () => {
         this.kill();
         this.sendEvent(new TerminatedEvent(false));
       });
@@ -224,15 +224,15 @@ class GDB extends GDBMixin(GDBBase) {
   }
 
   /**
-   * @param {{program: string, stopOnEntry: boolean, allStopMode: boolean, externalConsole: {path: string, closeOnExit: boolean} | null }} args 
+   * @param {{program: string, stopOnEntry: boolean, allStopMode: boolean, externalConsole: {path: string, closeTerminalOnEndOfSession: boolean, endSessionOnTerminalExit: boolean} | null }} args 
    */
   async start(args) {
     const {program, stopOnEntry, allStopMode, externalConsole } = args;
     if(externalConsole != null) {
-      const { path, closeOnExit } = externalConsole;
+      const { path, closeTerminalOnEndOfSession, endSessionOnTerminalExit } = externalConsole;
       const command = path == "" ? "x-terminal-emulator" : path;
-      this.#target.registerTerminal(await spawnExternalConsole({ terminal: command }, this.pid()), (code) => {
-        if(closeOnExit) {
+      this.#target.registerTerminal(await spawnExternalConsole({ terminal: command }, this.pid()), () => {
+        if(endSessionOnTerminalExit) {
           this.kill();
           this.sendEvent(new TerminatedEvent(false));
         }

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -210,9 +210,11 @@ async function spawnExternalConsole(config, pid) {
 async function spawnExternalRrConsole(config, rrArgs) {
   return new Promise((resolve, reject) => {
     const {path, addr, port, pid, traceWorkspace} = rrArgs;
+    const write_tty_to = `/tmp/midas-tty-for-gdb-${Math.ceil(Math.random() * 100000)}`;
     const terminal = config.terminal ?? "x-terminal-emulator";
     const cmd = `${path} replay -h ${addr} -s ${port} -p ${pid} -k ${traceWorkspace}`;
-    const child = _spawn(terminal, ["-e", cmd]);
+    const param = `sh -c "clear && ${cmd} && sleep 1000000000000000000"`;
+    const child = _spawn(terminal, ["-e", param]);
     resolve(new TerminalInterface(child, null, child.pid));
   });
 }


### PR DESCRIPTION
Fixes bug that didn't close terminals (or have session end). Now working properly for both session types.