### PR TITLE
Optimized builds now works

### DIFF
--- a/modules/python/stackframe.py
+++ b/modules/python/stackframe.py
@@ -169,7 +169,7 @@ class StackFrame:
         for b in iterate_frame_blocks(self.frame):
             blockvalues = []
             for symbol in b:
-                if symbol.is_variable and not symbol.is_argument and symbol.name not in names:
+                if symbol.is_variable and not symbol.is_argument and symbol.name not in names and not symbol.addr_class == gdb.SYMBOL_LOC_OPTIMIZED_OUT:
                     v = Variable.from_symbol(symbol, self.frame)
                     blockvalues.append(v)
                     vr = v.get_variable_reference()
@@ -194,7 +194,7 @@ class StackFrame:
         if not self.static_initialized:
             b = find_top_function_block(self.frame).static_block
             for symbol in b:
-                if symbol.is_variable:
+                if symbol.is_variable and not symbol.addr_class == gdb.SYMBOL_LOC_OPTIMIZED_OUT:
                     v = Variable.from_symbol(symbol, self.frame)
                     self.statics.append(v)
                     vr = v.get_variable_reference()
@@ -213,7 +213,7 @@ class StackFrame:
         result = []
         b = find_top_function_block(self.frame)
         for symbol in b:
-            if symbol.is_argument:
+            if symbol.is_argument and not symbol.addr_class == gdb.SYMBOL_LOC_OPTIMIZED_OUT:
                 v = Variable.from_symbol(symbol, self.frame)
                 vr = v.get_variable_reference()
                 if vr != 0:

--- a/modules/python/watch_variable.py
+++ b/modules/python/watch_variable.py
@@ -30,6 +30,11 @@ def find_variable(frame, name):
     it = midas_utils.get_global(frame, name)
     return it
 
+# todo(simon): make watch-variable request take a `STOP` parameter;
+#  this is so that we can say from VSCode that we want to watch for a variable up to scope `SCOPE`
+#  this is for performance reasons; if we're watching a variable that we know is not a global, then the user should
+#  be able to say that, that way we won't scan the entire scope every time which can be pretty costly.
+
 
 class WatchVariable(gdb.Command):
     """Not to be confused with watch point."""

--- a/test/cppworkspace/test/src/testcase_namespaces/pp.cpp
+++ b/test/cppworkspace/test/src/testcase_namespaces/pp.cpp
@@ -22,8 +22,15 @@ namespace prettyprinting {
         int i, j;
     };
 
+    struct Ref {
+        int& intRef;
+    };
+
     void main() {
         std::tuple<int, Hidden> tup{42, Hidden{1,2}};
+        auto&[id, hidden] = tup;
+        Ref intRef{id};
+        id++;
         bank_account b{1, "john doe", 1.05f};
         b.print_values();
         employee_t janedoe{2, "jane doe", new bank_account{2, "jane doe", 1.08f}, "manager"};


### PR DESCRIPTION
Technically not an "optimized build" thing, but more of a variable's address class being a computed location; these can be split in registers (or just live entirely in a register) - either way, there's no way to directly address them in memory.