### PR TITLE
Format of workspace

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
     "arrowParens": "always",
-    "printWidth": 130,
+    "printWidth": 120,
     "singleQuote": false,
     "bracketSpacing": true
 }

--- a/modules/activateDebuggerExtension.js
+++ b/modules/activateDebuggerExtension.js
@@ -13,9 +13,15 @@ function activateExtension(context, descriptorFactory) {
   context.subscriptions.push(...getVSCodeCommands(context));
   let provider = new ConfigurationProvider();
   context.subscriptions.push(
-    vscode.debug.registerDebugConfigurationProvider(provider.type, provider, vscode.DebugConfigurationProviderTriggerKind.Dynamic)
+    vscode.debug.registerDebugConfigurationProvider(
+      provider.type,
+      provider,
+      vscode.DebugConfigurationProviderTriggerKind.Dynamic
+    )
   );
-  context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory(provider.type, new DebugAdapterFactory()));
+  context.subscriptions.push(
+    vscode.debug.registerDebugAdapterDescriptorFactory(provider.type, new DebugAdapterFactory())
+  );
 
   let rrProvider = new RRConfigurationProvider();
   context.subscriptions.push(
@@ -25,7 +31,9 @@ function activateExtension(context, descriptorFactory) {
       vscode.DebugConfigurationProviderTriggerKind.Dynamic
     )
   );
-  context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory(rrProvider.type, new RRDebugAdapterFactory()));
+  context.subscriptions.push(
+    vscode.debug.registerDebugAdapterDescriptorFactory(rrProvider.type, new RRDebugAdapterFactory())
+  );
 }
 
 function deactivateExtension() {}

--- a/modules/commandsRegistry.js
+++ b/modules/commandsRegistry.js
@@ -63,7 +63,9 @@ function getVSCodeCommands(context) {
     if (fs.existsSync(debug_log)) {
       vscode.window.showTextDocument(vscode.Uri.parse(debug_log), { viewColumn: 1 });
       vscode.window.showTextDocument(vscode.Uri.parse(`${context.extensionPath}/error.log`), { viewColumn: 2 });
-      vscode.window.showTextDocument(vscode.Uri.parse(`${context.extensionPath}/performance_time.log`), { viewColumn: 3 });
+      vscode.window.showTextDocument(vscode.Uri.parse(`${context.extensionPath}/performance_time.log`), {
+        viewColumn: 3,
+      });
     } else {
       vscode.window.showInformationMessage("No logs have yet been created");
     }

--- a/modules/debugSession.js
+++ b/modules/debugSession.js
@@ -133,7 +133,10 @@ class MidasDebugSession extends DebugAdapter.DebugSession {
 
   // eslint-disable-next-line no-unused-vars
   async launchRequest(response, args, request) {
-    DebugAdapter.logger.setup(args.trace ? DebugAdapter.Logger.LogLevel.Verbose : DebugAdapter.Logger.LogLevel.Stop, false);
+    DebugAdapter.logger.setup(
+      args.trace ? DebugAdapter.Logger.LogLevel.Verbose : DebugAdapter.Logger.LogLevel.Stop,
+      false
+    );
     // wait until configuration has finished (and configurationDoneRequest has been called)
     await this.configIsDone.wait(1000);
     this.sendResponse(response);

--- a/modules/gdb.js
+++ b/modules/gdb.js
@@ -5,7 +5,13 @@ require("regenerator-runtime");
 const vscode = require("vscode");
 const { Source, ContinuedEvent, ExitedEvent } = require("@vscode/debugadapter");
 const path = require("path");
-const { InitializedEvent, StoppedEvent, BreakpointEvent, TerminatedEvent, ThreadEvent } = require("@vscode/debugadapter");
+const {
+  InitializedEvent,
+  StoppedEvent,
+  BreakpointEvent,
+  TerminatedEvent,
+  ThreadEvent,
+} = require("@vscode/debugadapter");
 
 // POSIX signals and their descriptions
 const SIGNALS = {
@@ -577,7 +583,9 @@ class GDB extends GDBMixin(GDBBase) {
       }
       case "watchpoint-trigger":
       case "read-watchpoint-trigger": {
-        this.sendEvent(newStoppedEvent("Watchpoint trigger", "Hardware watchpoint hit", this.allStopMode, payload.thread.id));
+        this.sendEvent(
+          newStoppedEvent("Watchpoint trigger", "Hardware watchpoint hit", this.allStopMode, payload.thread.id)
+        );
         break;
       }
       default:

--- a/modules/python/config.py
+++ b/modules/python/config.py
@@ -26,12 +26,14 @@ currentExecutionContext = None
 
 
 class ReferenceKey:
+
     def __init__(self, threadId, stackFrameId):
         self.threadId = threadId
         self.frameId = stackFrameId
 
 
 class VariableReferenceMap:
+
     def __init__(self):
         self.lookup = {}
 
@@ -49,6 +51,7 @@ def timeInvocation(f):
     if not isDevelopmentBuild:
         return f
     """Measure performance (time) of command or function"""
+
     @functools.wraps(f)
     def timer_decorator(*args, **kwargs):
         invokeBegin = time.perf_counter_ns()
@@ -57,9 +60,9 @@ def timeInvocation(f):
         logger = logging.getLogger("time-logger")
         # we don't need nano-second measuring, but the accuracy of the timer is nice.
         elapsed_time = int((invokeEnd - invokeBegin) / 1000)
-        logger.info("{:<30} executed in {:>10,} microseconds".format(
-            f.__qualname__, elapsed_time))
+        logger.info("{:<30} executed in {:>10,} microseconds".format(f.__qualname__, elapsed_time))
         return result
+
     return timer_decorator
 
 

--- a/modules/python/execution_context.py
+++ b/modules/python/execution_context.py
@@ -53,6 +53,7 @@ class CurrentExecutionContext:
 
 
 class ExecutionContext:
+
     def __init__(self, thread):
         self.thread = thread
         # Hallelujah (ironic) for type info. I miss Rust.
@@ -89,15 +90,13 @@ class ExecutionContext:
                 for sf in self.stack:
                     result.append(sf.get_vs_frame())
                 return result
-            res = frame_operations.find_first_identical_frames(
-                self.stack, f, 10)
+            res = frame_operations.find_first_identical_frames(self.stack, f, 10)
             if res is not None:
                 (x, newFrames) = res
                 self.stack = self.stack[x:]
                 tmp = self.stack
                 threadId = self.thread_id()
-                self.stack = [stackframe.StackFrame(
-                    f, threadId) for f in newFrames]
+                self.stack = [stackframe.StackFrame(f, threadId) for f in newFrames]
                 self.stack.extend(tmp)
             else:
                 self.clear_frames()
@@ -150,9 +149,9 @@ class ExecutionContext:
 
 
 class InvalidateExecutionContext(gdb.Command):
+
     def __init__(self, executionContexts):
-        super(InvalidateExecutionContext, self).__init__(
-            "gdbjs-thread-died", gdb.COMMAND_USER)
+        super(InvalidateExecutionContext, self).__init__("gdbjs-thread-died", gdb.COMMAND_USER)
         self.name = "thread-died"
         self.executionContexts = executionContexts
 
@@ -163,7 +162,5 @@ class InvalidateExecutionContext(gdb.Command):
             del self.executionContexts[threadId]
         except Exception as e:
             err_logger = config.error_logger()
-            config.log_exception(
-                err_logger, "Removing execution context failed: {}".format(e), e)
-        midas_utils.send_response(
-            self.name, {"ok": True}, midas_utils.prepare_command_response)
+            config.log_exception(err_logger, "Removing execution context failed: {}".format(e), e)
+        midas_utils.send_response(self.name, {"ok": True}, midas_utils.prepare_command_response)

--- a/modules/python/frame_operations.py
+++ b/modules/python/frame_operations.py
@@ -3,7 +3,7 @@ import gdb
 
 def frame_iterator(frame):
     while frame is not None:
-        yield(frame)
+        yield (frame)
         frame = frame.older()
 
 

--- a/modules/python/midas_utils.py
+++ b/modules/python/midas_utils.py
@@ -18,13 +18,11 @@ def type_is_primitive(valueType):
 def get_members_recursively(field, memberList, statics):
     if field.bitsize > 0:
         misc_logger = logging.getLogger("update-logger")
-        misc_logger.info("field {} is possibly a bitfield of size {}".format(
-            field.name, field.bitsize))
+        misc_logger.info("field {} is possibly a bitfield of size {}".format(field.name, field.bitsize))
     if hasattr(field, 'bitpos'):
         if field.is_base_class:
             for f in field.type.fields():
-                get_members_recursively(
-                    f, memberList=memberList, statics=statics)
+                get_members_recursively(f, memberList=memberList, statics=statics)
         else:
             if field.name is not None and not field.name.startswith("_vptr"):
                 memberList.append(field.name)
@@ -84,6 +82,7 @@ def send_response(name, result, prepareFnPtr):
 def value_is_reference(type):
     code = type.code
     return code == gdb.TYPE_CODE_PTR or code == gdb.TYPE_CODE_REF or code == gdb.TYPE_CODE_RVALUE_REF
+
 
 # When parsing closely related blocks, this is faster than gdb.parse_and_eval on average.
 

--- a/modules/python/reset_request.py
+++ b/modules/python/reset_request.py
@@ -3,7 +3,9 @@ import execution_context
 import midas_utils
 import config
 
+
 class ResetStateRequest(gdb.Command):
+
     def __init__(self, executionContexts, variableReferenceCounter, variableReferences):
         super(ResetStateRequest, self).__init__("gdbjs-reset-request", gdb.COMMAND_USER)
         self.name = "reset-request"

--- a/modules/python/scopes_request.py
+++ b/modules/python/scopes_request.py
@@ -7,7 +7,9 @@ from os import path
 import midas_utils
 import config
 
+
 class ScopesRequest(gdb.Command):
+
     def __init__(self, executionContexts):
         super(ScopesRequest, self).__init__("gdbjs-scopes-request", gdb.COMMAND_USER)
         self.name = "scopes-request"
@@ -25,7 +27,9 @@ class ScopesRequest(gdb.Command):
 
         for sf in ec.stack:
             if sf.frame_id() == frameId:
-                midas_utils.send_response(self.name, { "scopes": sf.get_scopes() }, midas_utils.prepare_command_response)
+                midas_utils.send_response(self.name, {"scopes": sf.get_scopes()},
+                                          midas_utils.prepare_command_response)
                 return
 
-        raise gdb.GdbError("No scopes found for frameId {} in execution context {}".format(frameId, refId.threadId))
+        raise gdb.GdbError("No scopes found for frameId {} in execution context {}".format(
+            frameId, refId.threadId))

--- a/modules/python/stackframe.py
+++ b/modules/python/stackframe.py
@@ -14,8 +14,7 @@ def create_stackframe_response(frame, alreadyReffedId=None):
         res = vs_stackframe_from_fn(frame, frame.function(), alreadyReffedId)
         return res
     except:
-        res = vs_stackframe_from_no_symtab(
-            frame.name(), frame, alreadyReffedId)
+        res = vs_stackframe_from_no_symtab(frame.name(), frame, alreadyReffedId)
         return res
 
 
@@ -47,8 +46,7 @@ def vs_stackframe_from_no_symtab(name, frame, alreadyReffedId=None):
     # DebugProtocol.Source
     src = None
     try:
-        src = {"name": path.basename(
-            sal.symtab.filename), "path": sal.symtab.fullname(), "sourceReference": 0}
+        src = {"name": path.basename(sal.symtab.filename), "path": sal.symtab.fullname(), "sourceReference": 0}
     except:
         pass
 
@@ -67,6 +65,7 @@ def vs_stackframe_from_no_symtab(name, frame, alreadyReffedId=None):
 
 
 class RegisterDescriptors:
+
     def __init__(self, frame):
         self.general = []
         self.sse = []
@@ -87,29 +86,29 @@ class RegisterDescriptors:
         }
 
     def read_general_registers(self, frame):
-        return [
-            RegisterDescriptors.register_vs_result(reg_desc, frame) for reg_desc in self.general
-        ]
+        return [RegisterDescriptors.register_vs_result(reg_desc, frame) for reg_desc in self.general]
 
     def read_sse_registers(self, frame):
-        return [
-            RegisterDescriptors.register_vs_result(reg_desc, frame) for reg_desc in self.sse
-        ]
+        return [RegisterDescriptors.register_vs_result(reg_desc, frame) for reg_desc in self.sse]
 
     def read_mmx_registers(self, frame):
-        return [
-            RegisterDescriptors.register_vs_result(reg_desc, frame) for reg_desc in self.mmx
-        ]
+        return [RegisterDescriptors.register_vs_result(reg_desc, frame) for reg_desc in self.mmx]
 
 
 REGISTER_DESCRIPTOR_SETS: RegisterDescriptors = None
 
 
 def scope(name, variableReference, presentationHint, expensive=False):
-    return {"name": name, "variablesReference": variableReference, "expensive": expensive, "presentationHint": presentationHint}
+    return {
+        "name": name,
+        "variablesReference": variableReference,
+        "expensive": expensive,
+        "presentationHint": presentationHint
+    }
 
 
 class StackFrame:
+
     def __init__(self, frame, threadId):
         """Creates a stack frame. Used for querying about local variables, arguments etc.
         Mutates the global VariableReference map by registering it's 3 'top level' variable references."""
@@ -121,10 +120,8 @@ class StackFrame:
         self.localsReference = config.next_variable_reference()
         self.args = []
         self.argsReference = config.next_variable_reference()
-        self.watchVariableReferences: dict[int,
-                                           Union[Variable, BaseClass, StaticVariable]] = {}
-        self.variableReferences: dict[int,
-                                      Union[Variable, BaseClass, StaticVariable]] = {}
+        self.watchVariableReferences: dict[int, Union[Variable, BaseClass, StaticVariable]] = {}
+        self.variableReferences: dict[int, Union[Variable, BaseClass, StaticVariable]] = {}
         self.registerReference = config.next_variable_reference()
 
         self.statics = []
@@ -139,8 +136,7 @@ class StackFrame:
             scope("Locals", self.localsReference, "locals"),
             scope("Args", self.argsReference, "arguments"),
             scope("Register", self.registerReference, "register"),
-            scope("Statics", self.staticsReference, "static",
-                  expensive=True)  # _might_ be expensive
+            scope("Statics", self.staticsReference, "static", expensive=True)  # _might_ be expensive
         ]
 
         config.variableReferences.add_mapping(self.localsReference, self)

--- a/modules/python/stacktrace_request.py
+++ b/modules/python/stacktrace_request.py
@@ -5,16 +5,15 @@ import config
 
 
 class StackTraceRequest(gdb.Command):
+
     def __init__(self, executionContexts):
-        super(StackTraceRequest, self).__init__(
-            "gdbjs-stacktrace-request", gdb.COMMAND_USER)
+        super(StackTraceRequest, self).__init__("gdbjs-stacktrace-request", gdb.COMMAND_USER)
         self.name = "stacktrace-request"
         self.executionContexts = executionContexts
 
     @config.timeInvocation
     def invoke(self, arguments, from_tty):
-        [threadId, start, levels] = midas_utils.parse_command_args(
-            arguments, int, int, int)
+        [threadId, start, levels] = midas_utils.parse_command_args(arguments, int, int, int)
         try:
             ec = self.executionContexts.get(threadId)
             if ec is None:
@@ -40,12 +39,11 @@ class StackTraceRequest(gdb.Command):
             if stack_frames is None:
                 stack_frames = []
             result = {"stackFrames": stack_frames, "totalFrames": total_frames}
-            midas_utils.send_response(
-                self.name, result, midas_utils.prepare_command_response)
+            midas_utils.send_response(self.name, result, midas_utils.prepare_command_response)
         except Exception as e:
             # means selectThreadAndFrame failed; we have no frames from `start` and down
             err_logger = config.error_logger()
-            config.log_exception(err_logger, "Error occured in StackTraceRequest(threadId={}, start={}, levels={}) {}".format(
-                threadId, start, levels, e), e)
-            midas_utils.send_response(
-                self.name, {"stackFrames": []}, midas_utils.prepare_command_response)
+            config.log_exception(
+                err_logger, "Error occured in StackTraceRequest(threadId={}, start={}, levels={}) {}".format(
+                    threadId, start, levels, e), e)
+            midas_utils.send_response(self.name, {"stackFrames": []}, midas_utils.prepare_command_response)

--- a/modules/python/variables_request.py
+++ b/modules/python/variables_request.py
@@ -5,13 +5,12 @@ import config
 
 
 class VariableRequest(gdb.Command):
+
     def __init__(self, executionContexts):
         import execution_context
-        super(VariableRequest, self).__init__(
-            "gdbjs-variable-request", gdb.COMMAND_USER)
+        super(VariableRequest, self).__init__("gdbjs-variable-request", gdb.COMMAND_USER)
         self.name = "variable-request"
-        self.executionContexts: dict[int,
-                                     execution_context.ExecutionContext] = executionContexts
+        self.executionContexts: dict[int, execution_context.ExecutionContext] = executionContexts
 
     @config.timeInvocation
     def invoke(self, variableReference, from_tty):
@@ -20,23 +19,21 @@ class VariableRequest(gdb.Command):
             refId = config.variableReferences.get_context(variableReference)
             if refId is None:
                 # todo(simon): this is where we start checking for watch variables, as they are context-independent and re-evaluated in every context that gets selected
-                raise gdb.GdbError(
-                    "No refId referenced by {} exists".format(variableReference))
+                raise gdb.GdbError("No refId referenced by {} exists".format(variableReference))
             ec = self.executionContexts.get(refId.threadId)
             if ec is None:
-                raise gdb.GdbError(
-                    "No execution context is referencing {}".format(variableReference))
+                raise gdb.GdbError("No execution context is referencing {}".format(variableReference))
             sf = ec.get_stackframe(refId.frameId)
             if sf.manages_variable_reference(variableReference):
                 res = sf.get(variableReference)
                 result = {"variables": res}
-                midas_utils.send_response(
-                    self.name, result, midas_utils.prepare_command_response)
+                midas_utils.send_response(self.name, result, midas_utils.prepare_command_response)
             else:
                 raise gdb.GdbError("Stack frame {} does not manage variable reference {}".format(
                     refId.frameId, variableReference))
         except Exception as e:
-            config.log_exception(config.error_logger(), "Variable Request failed for variable reference {} (in exec context {}): {}".format(
-                variableReference, refId.threadId, e), e)
-            midas_utils.send_response(
-                self.name, {"variables": []}, midas_utils.prepare_command_response)
+            config.log_exception(
+                config.error_logger(),
+                "Variable Request failed for variable reference {} (in exec context {}): {}".format(
+                    variableReference, refId.threadId, e), e)
+            midas_utils.send_response(self.name, {"variables": []}, midas_utils.prepare_command_response)

--- a/modules/python/watch_variable.py
+++ b/modules/python/watch_variable.py
@@ -3,10 +3,16 @@ import config
 import midas_utils
 
 
-def response(success, message, result, type=None, variableReference=0, namedVariables=None, indexedVariables=None, memoryReference=None):
+def response(success,
+             message,
+             result,
+             type=None,
+             variableReference=0,
+             namedVariables=None,
+             indexedVariables=None,
+             memoryReference=None):
     return {
-        "body":
-        {
+        "body": {
             "result": result,
             "type": type,
             "variablesReference": variableReference,
@@ -30,6 +36,7 @@ def find_variable(frame, name):
     it = midas_utils.get_global(frame, name)
     return it
 
+
 # todo(simon): make watch-variable request take a `STOP` parameter;
 #  this is so that we can say from VSCode that we want to watch for a variable up to scope `SCOPE`
 #  this is for performance reasons; if we're watching a variable that we know is not a global, then the user should
@@ -40,8 +47,7 @@ class WatchVariable(gdb.Command):
     """Not to be confused with watch point."""
 
     def __init__(self, executionContexts):
-        super(WatchVariable, self).__init__(
-            "gdbjs-watch-variable", gdb.COMMAND_USER)
+        super(WatchVariable, self).__init__("gdbjs-watch-variable", gdb.COMMAND_USER)
         self.name = "watch-variable"
         self.executionContexts = executionContexts
 
@@ -51,8 +57,7 @@ class WatchVariable(gdb.Command):
             [expr, frameId] = midas_utils.parse_command_args(args, str, int)
             refId = config.variableReferences.get_context(frameId)
             if refId is None:
-                raise gdb.GdbError(
-                    "No variable reference mapping for frame id {} exists".format(frameId))
+                raise gdb.GdbError("No variable reference mapping for frame id {} exists".format(frameId))
             ec = self.executionContexts.get(refId.threadId)
             if ec is None:
                 raise gdb.GdbError("Execution context does not exist")
@@ -60,18 +65,23 @@ class WatchVariable(gdb.Command):
             components = expr.split(".")
             it = find_variable(frame, components[0])
             if it is None:
-                midas_utils.send_response(self.name, response(result="no symbol with that name in context",
-                                          success=False, message="could not evaluate"), midas_utils.prepare_command_response)
+                midas_utils.send_response(
+                    self.name,
+                    response(result="no symbol with that name in context",
+                             success=False,
+                             message="could not evaluate"), midas_utils.prepare_command_response)
             else:
                 sf = ec.get_stackframe(frameId)
                 v = sf.add_watched_variable(expr, it)
                 res = v.to_vs()
-                result = response(success=True, message=None, result=res["value"], type="{}".format(
-                    v.get_type()), variableReference=v.get_variable_reference())
-                midas_utils.send_response(
-                    self.name, result, midas_utils.prepare_command_response)
+                result = response(success=True,
+                                  message=None,
+                                  result=res["value"],
+                                  type="{}".format(v.get_type()),
+                                  variableReference=v.get_variable_reference())
+                midas_utils.send_response(self.name, result, midas_utils.prepare_command_response)
         except Exception as e:
-            config.log_exception(config.error_logger(),
-                                 "{} failed: {}".format(self.name, e), e)
-            midas_utils.send_response(self.name, response(
-                success=False, message="Could not be evaluated", result=None), midas_utils.prepare_command_response)
+            config.log_exception(config.error_logger(), "{} failed: {}".format(self.name, e), e)
+            midas_utils.send_response(self.name,
+                                      response(success=False, message="Could not be evaluated", result=None),
+                                      midas_utils.prepare_command_response)

--- a/modules/python/watchpoint_request.py
+++ b/modules/python/watchpoint_request.py
@@ -1,7 +1,9 @@
 import gdb
 import midas_utils
 
+
 class SetWatchPoint(gdb.Command):
+
     def __init__(self):
         super(SetWatchPoint, self).__init__("gdbjs-watchpoint", gdb.COMMAND_USER)
         self.name = "watchpoint"
@@ -17,4 +19,4 @@ class SetWatchPoint(gdb.Command):
         else:
             raise RuntimeError("Unknown watchpoint class")
         bp = gdb.breakpoints()[-1]
-        midas_utils.send_response(self.name, { "number": bp.number }, midas_utils.prepare_command_response)
+        midas_utils.send_response(self.name, {"number": bp.number}, midas_utils.prepare_command_response)


### PR DESCRIPTION
Added the formatter yapf for Python, finalized the javascript settings.

From now on, every save will format and going forward after release we no longer have to worry, no matter if it's python code or javascript code.

120 line width. Because I hate 80 line width it clutters up everything and splits what should be one liners, doing "one" thing into multiple lines making the code *way* harder to reason about quickly.