### PR TITLE
Updated PID picker for attach sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,26 @@ However, you shouldn't have to fill out a placeholder for yourself, VSCode shoul
 
 ![Default Launch config](docs/launchconfig.gif)
 
+## Attach session
+Attaching to a running process is basically done and setup the same way. Midas will provide a default setting:
+
+```json
+{
+  "type": "midas-gdb",
+  "request": "attach",
+  "name": "Attach",
+  "program": "${workspaceFolder}",
+  "cwd": "${workspaceFolder}",
+  "trace": "Off",
+  "pid": "${command:getPid}",
+  "gdbPath": "gdb",
+  "setupCommands": [],
+  "attachOnFork": false
+}
+```
+
+Leave PID field as is (or remove the field entirely) and you will be asked for it at debug session launch where you can type either the PID directly or the process name and get a list of PID's to choose from (if only 1 exists, it automatically gets picked).
+
 ## Usage
 
 Since VSCode is aimed to be as general as possible, some functionality might never be represented in the UI - as such it might appear unintuitive. [Describing such functionality is found here](docs/USAGE.md), like setting watch points, formatting displayed values etc. It's recommended to skim through, to get to know useful Midas features.

--- a/modules/commandsRegistry.js
+++ b/modules/commandsRegistry.js
@@ -1,6 +1,7 @@
 "use strict";
 const { execSync } = require("child_process");
 const fs = require("fs");
+const { getPid } = require("./utils");
 /**
  * @typedef { import("vscode").Disposable } Disposable
  */
@@ -106,7 +107,9 @@ function getVSCodeCommands(context) {
     }
   });
 
-  return [rrRecord, continueAll, pauseAll, reverseFinish, hotReloadScripts, displayLogs, issueGithubReport];
+  const getPid_ = registerCommand("midas.getPid", getPid);
+
+  return [rrRecord, continueAll, pauseAll, reverseFinish, hotReloadScripts, displayLogs, issueGithubReport, getPid_];
 }
 
 module.exports = {

--- a/modules/debugSession.js
+++ b/modules/debugSession.js
@@ -847,7 +847,7 @@ class MidasDebugSession extends DebugAdapter.DebugSession {
   }
 
   disposeTerminal() {
-    this.#terminal.dispose();
+    if (this.#terminal) this.#terminal.dispose();
   }
 
   get terminal() {

--- a/modules/gdb.js
+++ b/modules/gdb.js
@@ -168,7 +168,10 @@ class GDB extends GDBMixin(GDBBase) {
     trace = this.#target.buildSettings.trace;
     await this.init();
     this.#target.customRequest(CustomRequests.ClearCheckpoints);
-    // await this.attachOnFork();
+    if (this.#target.getSpawnConfig().attachOnFork) {
+      await this.attachOnFork();
+    }
+
     this.registerAsAllStopMode();
     // const { getVar, midasPy } = require("./scripts");
     await this.setup();
@@ -239,6 +242,9 @@ class GDB extends GDBMixin(GDBBase) {
     }
     await this.execCLI("set breakpoint pending on");
     await this.setPrintOptions(printOptions);
+    if (this.#target.getSpawnConfig().attachOnFork) {
+      await this.attachOnFork();
+    }
     if (stopOnEntry) {
       await this.execMI("-exec-run --start");
     } else {
@@ -948,7 +954,7 @@ class GDB extends GDBMixin(GDBBase) {
     gdbProcess.kill(signal);
     if (this.disposeOnExit) this.#target.disposeTerminal();
     else {
-      this.#target.terminal.disposeChildren();
+      if (this.#target.terminal) this.#target.terminal.disposeChildren();
     }
   }
 

--- a/modules/providers/midas-gdb.js
+++ b/modules/providers/midas-gdb.js
@@ -2,7 +2,7 @@ const vscode = require("vscode");
 const { MidasDebugSession } = require("../debugSession");
 const fs = require("fs");
 const { ConfigurationProviderInitializer } = require("./initializer");
-const { isNothing, resolveCommand, ContextKeys, showErrorPopup } = require("../utils");
+const { isNothing, resolveCommand, ContextKeys, showErrorPopup, getPid } = require("../utils");
 const { LaunchSpawnConfig, AttachSpawnConfig } = require("../spawn");
 
 const initializer = (config) => {
@@ -65,10 +65,8 @@ class ConfigurationProvider extends ConfigurationProviderInitializer {
 
     if (config.request == "attach") {
       if (!config.pid) {
-        const options = { canPickMany: false, ignoreFocusOut: true, title: "Select process to debug" };
-        const pid = await vscode.window.showInputBox(options);
-        if (!pid) {
-          await vscode.window.showInformationMessage("You must provide a pid for attach requests.");
+        const pid = await getPid();
+        if (isNothing(pid)) {
           return null;
         }
         config.pid = pid;

--- a/modules/spawn.js
+++ b/modules/spawn.js
@@ -45,6 +45,7 @@ class SpawnConfig {
     this.setupCommands = launchJson.setupCommands;
     this.binary = launchJson.program;
     this.traceSettings = new MidasRunMode(launchJson);
+    this.attachOnFork = launchJson.attachOnFork ?? false;
   }
 
   build() {

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -387,6 +387,43 @@ function getVersion(pathToBinary) {
   });
 }
 
+async function getPid() {
+  const input = await vscode.window.showInputBox({
+    prompt: "Type PID or name of process to get a list to select from",
+    placeHolder: "123 | foo",
+    title: "Process to attach to",
+  });
+  if (input) {
+    if (/[^\d]/.test(input)) {
+      const cmd = `pidof ${input}`;
+      try {
+        const data = execSync(cmd).toString();
+        const options = {
+          canPickMany: false,
+          ignoreFocusOut: true,
+          title: `${input}: Select PID to attach to `,
+        };
+        let split = data.split(" ");
+        if (split.length == 1) {
+          return split[0].trim();
+        }
+        return await vscode.window.showQuickPick(
+          split.map((e) => e.trim()),
+          options
+        );
+      } catch (e) {
+        vscode.window.showInformationMessage(`No process with that name: ${input}`);
+        return null;
+      }
+    } else {
+      return input;
+    }
+  } else {
+    vscode.window.showInformationMessage("No PID (or process) selected");
+    return null;
+  }
+}
+
 module.exports = {
   buildTestFiles,
   getFunctionName,
@@ -405,4 +442,5 @@ module.exports = {
   parseSemVer,
   getVersion,
   requiresMinimum,
+  getPid,
 };

--- a/package.json
+++ b/package.json
@@ -214,6 +214,10 @@
                 "type": "array",
                 "description": "GDB Commands to run before debugging."
               },
+              "attachOnFork": {
+                "type": "boolean",
+                "description": "Whether or not GDB should attach on fork, for instance if you're debugging a target that spawns new processes with `fork`"
+              },
               "externalConsole": {
                 "type": "object",
                 "default": {
@@ -246,13 +250,11 @@
             }
           },
           "attach": {
-            "required": [
-              "pid"
-            ],
             "properties": {
               "pid": {
-                "type": "string",
-                "description": "pid of the process to attach to"
+                "type": "number",
+                "description": "Pid of the process to attach to. Can be left out entirely and entered upon debug launch.",
+                "default": "${command:getPid}"
               },
               "program": {
                 "type": "string",
@@ -294,6 +296,10 @@
               "gdbOptions": {
                 "type": "array",
                 "description": "GDB Arguments."
+              },
+              "attachOnFork": {
+                "type": "boolean",
+                "description": "Whether or not GDB should attach on fork, for instance if you're debugging a target that spawns new processes with `fork`"
               }
             }
           }
@@ -315,7 +321,7 @@
             "request": "attach",
             "name": "Midas Attach",
             "program": "${1:program}",
-            "pid": "${2:pid}",
+            "pid": "${command:getPid}",
             "trace": "${3:Off}",
             "cwd": "${workspaceFolder}",
             "setupCommands": []
@@ -336,7 +342,8 @@
               "trace": "${3:Off}",
               "gdbPath": "${4:gdb}",
               "allStopMode": true,
-              "setupCommands": []
+              "setupCommands": [],
+              "attachOnFork": false
             }
           },
           {
@@ -347,15 +354,17 @@
               "type": "midas-gdb",
               "request": "attach",
               "name": "${1:Attach to process}",
-              "program": "${2:program}",
-              "pid": "${3:pid}",
+              "program": "^\"\\${workspaceFolder}\"",
               "cwd": "^\"\\${workspaceFolder}\"",
               "trace": "${4:Off}",
+              "pid": "^\"\\${command:getPid}\"",
               "gdbPath": "${5:gdb}",
-              "setupCommands": []
+              "setupCommands": [],
+              "attachOnFork": false
             }
           }
-        ]
+        ],
+        "variables": {"getPid": "midas.getPid"}
       },
       {
         "type": "midas-rr",


### PR DESCRIPTION
Asks user for PID to attach to. User can also enter process name
and get a list of PIDS to choose from with that name, currently running
(and visible by the `pidof foo` command)

Updated README to contain attach settings as well.