### PR TITLE
Prettyprint subscripting

### DIFF
--- a/docs/BUGS.MD
+++ b/docs/BUGS.MD
@@ -1,1 +1,4 @@
 # Reported & Untreated bugs
+
+When watching a variable, you can only watch 1 instance of the same variable. Thus, if you watch a range `foo[2:4]`
+you can't also watch `foo[4:9]`, only one of them will be shown. This will be fixed in future releases.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Create specific handlers for all VSCode requests directly in Python
 
+## [0.4.7] - 2022-07-06
+- Added ability to get range of pretty printed child values for watch variables
+
 ## [0.4.0] - 2022-05-23
 - Hooked up Midas to work with VSCode Disassembly view
 - Added "Create issue log" command

--- a/modules/python/stackframe.py
+++ b/modules/python/stackframe.py
@@ -302,7 +302,6 @@ class StackFrame:
         tmp = self.watch_variables.get(expr)
         if tmp is not None:
             vr = tmp.get_variable_reference()
-        config.update_logger().debug("Adding {}".format(expr))
         v = Variable.from_value(expr, variable, expr, start, end)
         # assume the previous VRID, no need to keep incrementing; since we know the variable by expr anyway
         # this comes with the added benefit of the Python reference at self.watchVariableReferences[vr] going to 0 => de alloc

--- a/modules/python/stackframe.py
+++ b/modules/python/stackframe.py
@@ -296,13 +296,14 @@ class StackFrame:
     def frame_id(self):
         return self.localsReference
 
-    def add_watched_variable(self, expr, variable):
+    def add_watched_variable(self, expr, variable, start = 0, end = None):
         """ Adds variable to watch if it doesn't exist and returns created/existing `Variable`"""
         vr = None
         tmp = self.watch_variables.get(expr)
         if tmp is not None:
             vr = tmp.get_variable_reference()
-        v = Variable.from_value(expr, variable)
+        config.update_logger().debug("Adding {}".format(expr))
+        v = Variable.from_value(expr, variable, expr, start, end)
         # assume the previous VRID, no need to keep incrementing; since we know the variable by expr anyway
         # this comes with the added benefit of the Python reference at self.watchVariableReferences[vr] going to 0 => de alloc
         v.variableRef = -1 if vr is None else vr
@@ -320,3 +321,9 @@ class StackFrame:
 
     def set_free_floating(self, expr):
         self.freeFloating.append(expr)
+
+    def add_free_floating_watched_variable(self, expr, it, start = 0, end = None):
+        var = self.add_watched_variable(expr, it, start, end)
+        self.ec.set_free_floating(expr, var)
+        self.set_free_floating(expr)
+        return var

--- a/modules/python/variable.py
+++ b/modules/python/variable.py
@@ -76,6 +76,8 @@ class ReferencedValue:
         pp = gdb.default_visualizer(value)
         if pp is not None:
             if hasattr(pp, "children"):
+                # if user wrote foo[0], unless we set end = start + 1, we will return nothing, due to how islice works
+                end = start + 1 if start == end else end
                 for (name, value) in itertools.islice(pp.children(), start, end):
                     v = Variable.from_value(name, value)
                     vref = v.get_variable_reference()

--- a/modules/python/watch_variable.py
+++ b/modules/python/watch_variable.py
@@ -57,6 +57,8 @@ class WatchVariable(gdb.Command):
                 raise gdb.GdbError("Execution context does not exist")
             var = ec.free_floating_watchvariable(expr)
             if var is not None:
+                var.start = begin
+                var.end = end
                 res = var.to_vs()
                 result = response(success=True,
                                     message=None,
@@ -99,6 +101,8 @@ class WatchVariable(gdb.Command):
                                     variableReference=var.get_variable_reference())
                         midas_utils.send_response(self.name, result, midas_utils.prepare_command_response)
                         return
+                raise gdb.GdbError("{} Could not be evaluated".format(expr))
+
             for comp in components[1:]:
                 it = it[comp]
                 if it is None:

--- a/test/cppworkspace/test/src/main.cpp
+++ b/test/cppworkspace/test/src/main.cpp
@@ -10,6 +10,7 @@
 #include "testcase_namespaces/test_ptrs.hpp"
 #include <iostream>
 #include <iterator>
+#include <map>
 #include <number.hpp>
 #include <string>
 #include <vector>
@@ -69,10 +70,23 @@ inline void alter_t(T &t) {
 }
 
 int main(int argc, const char **argv) {
+  std::map<int, std::string> mumbojumbo;
+  mumbojumbo[10] = "hello";
+  mumbojumbo[1337] = "world";
+  mumbojumbo[9] = "main";
+  mumbojumbo[23] = "foo()";
+  mumbojumbo[19] = "bar()";
+  mumbojumbo[190] = "check()";
   std::vector<std::string> foos[3]{};
+  // testing for pretty printed child values of pretty printed type behind a pointer
+  auto foovec = new std::vector<std::string>{};
+
   signal(SIGINT, interrupt_signal);
   std::vector<std::string> captured_args;
   std::copy(argv, argv + argc, std::back_inserter(captured_args));
+  for(const auto& arg : captured_args) {
+    foovec->push_back(arg);
+  }
   std::copy(argv, argv + argc, std::back_inserter(foos[0]));
   std::copy(argv, argv + argc, std::back_inserter(foos[1]));
   std::copy(argv, argv + argc, std::back_inserter(foos[2]));


### PR DESCRIPTION
`foo[1:3]` now works for pretty printed values as well.