### PR TITLE
Fixes #181

### DIFF
--- a/modules/python/dap-wrapper/dap.py
+++ b/modules/python/dap-wrapper/dap.py
@@ -746,8 +746,6 @@ def set_bps(args):
             else:
                 bp = gdb.Breakpoint(source=path, line=int(bp_req.get("line")))
                 bp.condition = bp_req.get("condition")
-                # if bp_req.get("hitCondition") is not None:
-                # bp.ignore_count = int(gdb.parse_and_eval(bp_req.get("hitCondition"), global_context=True))
                 breakpoints[path][bp_key] = bp
 
         diff = set(previous_bp_state.keys()) - set(breakpoints[path].keys())
@@ -1253,11 +1251,6 @@ gdb.events.breakpoint_created.connect(
 gdb.events.breakpoint_modified.connect(
     lambda bp: send_event(
         "breakpoint", {"reason": "changed", "breakpoint": bp_to_ui(bp)}
-    )
-)
-gdb.events.breakpoint_deleted.connect(
-    lambda bp: send_event(
-        "breakpoint", {"reason": "removed", "breakpoint": {"id": bp.number}}
     )
 )
 


### PR DESCRIPTION
TLDR; DAP is not good enough, also
any "dynamic" removal of breakpoints will not be notified to VSCode.

I've taken an executive decision here with respect to removed breakpoints.

The removal of a breakpoint will not be notified to VSCode going forward, as this breaks with how the Debug Adapter Protocol "knows of" breakpoints.

For instance, in VSCode, one can disable a breakpoint by unchecking the checkbox; this will trigger a new 'breakpoints' request, that does not contain the unchecked breakpoint. But from a protocol perspective, what does this mean? That it was deleted or just disabled? The protocol gives us no way of knowing, unfortunately.

So when the breakpoint is deleted after the request, a notification of "breakpoint removed" is sent to VSCode, and it will delete the breakpoint that was unchecked from it's UI, unfortunately.

This is *probably* more of a "you problem" for VSCode and or the DAP, than a Midas issue, but this workaround will do.

This workaround however means that any breakpoint removal not done by the user explicitly via the vscode UI (for instance, a breakpoint removed by some Python script), will not be notified to VSCode of. But it's a price I'm willing to pay.