### PR TITLE
Silence DAP errors

### DIFF
--- a/modules/gdb-dap/debugSession.js
+++ b/modules/gdb-dap/debugSession.js
@@ -247,7 +247,7 @@ class MidasDAPSession extends DebugAdapter.DebugSession {
     this.gdb.response_connect((response) => {
       if(!response.success) {
         const err = (response.body.error ?? { stacktrace: "No stack trace info" }).stacktrace;
-        this.sendErrorResponse(response, 0, err);
+        console.log(`[request error]: ${response.command} failed\n${err}`);
       }
       switch(response.command) {
         case "variables":


### PR DESCRIPTION
These errors tend to be ok to just ignore. We can't control VSCode or when it sends requests.

These errors come from the async nature of DAP. If a chain of requests come in out of order or is interrupted by the user with an "resuming request", some requests are going to fail - that is ok. We shouldn't inform the user of these though.