### PR TITLE
Fix hex formatting for register values

### DIFF
--- a/modules/python/dap-wrapper/variables_reference.py
+++ b/modules/python/dap-wrapper/variables_reference.py
@@ -440,6 +440,10 @@ class RegistersReference(VariablesReference):
                 ref = create_eager_var_ref(reg.name, value, None)
                 res.append(ref.ui_data(format))
             else:
-                res.append({ "name": reg.name, "value": f"{value}", "variablesReference": 0 })
+                if value.type.code == gdb.TYPE_CODE_INT and format is not None and format["hex"]:
+                    formattedValue = value.format_string(format="x")
+                else:
+                    formattedValue = f"{value}"
+                res.append({ "name": reg.name, "value": formattedValue, "variablesReference": 0 })
 
         return res


### PR DESCRIPTION
Previously we would ignore the hex formatting setting for register values. Attempting to format the register value with hex() would produce a "negative" hex value for values with the sign bit set which is rarely useful. Therefore use format_string to format the register value if hex is requested.