### PR TITLE
Fix instruction breakpoints

### DIFF
--- a/modules/python/dap-wrapper/dap.py
+++ b/modules/python/dap-wrapper/dap.py
@@ -934,8 +934,8 @@ def set_ins_bps(args):
         if bp_key in previous_bp_state:
             breakpoints["address"][bp_key] = previous_bp_state[bp_key]
         else:
-            address = int(bp_req.get("instructionReference"), 16)
-            bp = gdb.Breakpoint(spec=f"*0x{address}")
+            address = int(bp_req.get("instructionReference"), 16) + safeInt(bp_req.get("offset"))
+            bp = gdb.Breakpoint(spec=f"*{address}")
             bp.condition = bp_req.get("condition")
             # if bp_req.get("hitCondition") is not None:
             # bp.ignore_count = int(gdb.parse_and_eval(bp_req.get("hitCondition"), global_context=True))


### PR DESCRIPTION
- Instruction reference was being converted to decimal and then passed to gdb with a 0x prefix causing the decimal representation to be interpreted as hex. Fix it.
- Add offset if present. Previously offset was ignored causing the breakpoint to be set at the wrong address.