### PR TITLE
Raise perf_event_paranoid requirement to <= 2

### DIFF
--- a/modules/providers/midas-rr.js
+++ b/modules/providers/midas-rr.js
@@ -11,7 +11,7 @@ const { GdbDAPSession } = require("../dap/gdb");
 const { getExtensionPathOf } = require("../utils/sysutils");
 
 const initializerPopupChoices = {
-  perf_event_paranoid: [
+  perfEventParanoid: [
     {
       title: "Read more...",
       action: async () => {
@@ -46,12 +46,12 @@ const initializer = async (config) => {
     config.setupCommands = [];
   }
 
-  const perf_event_paranoid = krnl.readPerfEventParanoid();
-  if (perf_event_paranoid > 1) {
+  const perfEventParanoid = krnl.readPerfEventParanoid();
+  if (perfEventParanoid > 2) {
     let choice = await showErrorPopup(
-      "perf_event_paranoid not set to <= 1.",
+      "perf_event_paranoid not set to <= 2.",
       "rr needs it to be set to 1 to be performant.",
-      initializerPopupChoices.perf_event_paranoid,
+      initializerPopupChoices.perfEventParanoid,
     );
     if (choice) await choice.action();
     throw new Error("Canceled");

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debug",
     "rr"
   ],
-  "version": "0.25.1",
+  "version": "0.25.2",
   "engines": {
     "vscode": "^1.96.0"
   },


### PR DESCRIPTION
RR and Linux kernel updates has made it possible to record and replay using 2 as a setting. See release info from rr:
https://github.com/rr-debugger/rr/releases#:~:text=As,practice

Closes #227